### PR TITLE
Return 400 response when request doesn't originate from https

### DIFF
--- a/taskclustercoalesce/web.py
+++ b/taskclustercoalesce/web.py
@@ -1,12 +1,12 @@
 import traceback
 import sys
 import os
-import flask
-from flask import jsonify
 import redis
+from flask import abort, jsonify, request, Flask
+from functools import wraps
 from urlparse import urlparse
 
-app = flask.Flask(__name__)
+app = Flask(__name__)
 
 pf = "coalesce.v1."
 
@@ -22,7 +22,32 @@ rds = redis.Redis(host=redis_url.hostname,
                   decode_responses=True)
 
 
+@app.errorhandler(400)
+def handle_bad_request(error):
+    response = jsonify({'message': error.description})
+    response.status_code = 400
+    return response
+
+
+def ssl_required(fn):
+    """
+    Heroku terminates all SSL traffic before it reaches the application,
+    but injects a header to indicate if the request originated from HTTPS.
+    This decorator checks for the header HTTP_X_FORWARDED_PROTO and if none
+    is found, returns a 400 Bad Request
+    """
+    @wraps(fn)
+    def decorated_view(*args, **kwargs):
+        if request.headers.get('HTTP_X_FORWARDED_PROTO'):
+            return fn(*args, **kwargs)
+        else:
+            abort(400, 'HTTPS required; HTTP_X_FORWARDED_PROTO header missing')
+        return fn(*args, **kwargs)
+    return decorated_view
+
+
 @app.route('/')
+@ssl_required
 def root():
     """
     GET: Return an index of available api
@@ -32,6 +57,7 @@ def root():
 
 
 @app.route('/v1/list')
+@ssl_required
 def coalasce_lists():
     """
     GET: returns a list of all coalesced objects load into the listener
@@ -44,16 +70,18 @@ def coalasce_lists():
 
 
 @app.route('/v1/stats')
+@ssl_required
 def stats():
     """
     GET: returns stats
     """
     pf_key = pf + 'stats'
     stats = rds.hgetall(pf_key)
-    return flask.jsonify(**stats)
+    return jsonify(**stats)
 
 
 @app.route('/v1/list/<key>')
+@ssl_required
 def list(key):
     """
     GET: returns list


### PR DESCRIPTION
Let's explicitly not redirect non https and just return a 400