### PR TITLE
Redirect http to https when run on heroku dyno

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 worker: python -u taskclustercoalesce/listener.py
-web: gunicorn taskclustercoalesce.web:app --log-file -
+web: gunicorn --config=config/gunicorn.py taskclustercoalesce.web:app --log-file -

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -1,0 +1,6 @@
+forwarded_allow_ips = '*'
+secure_scheme_headers = {
+    'X-FORWARDED-PROTOCOL': 'ssl',
+    'X-FORWARDED-PROTO': 'https',
+    'X-FORWARDED-SSL': 'on'
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 amqp==1.4.7
 anyjson==0.3.3
 Flask==0.10.1
+Flask-SSLify==0.1.5
 gunicorn==19.4.1
 itsdangerous==0.24
 Jinja2==2.8

--- a/taskclustercoalesce/web.py
+++ b/taskclustercoalesce/web.py
@@ -3,13 +3,19 @@ import sys
 import os
 import flask
 import time
-from flask import jsonify
 import redis
+from flask import jsonify
 from urlparse import urlparse
+from werkzeug.contrib.fixers import ProxyFix
+from flask_sslify import SSLify
 
 starttime = time.time()
 
 app = flask.Flask(__name__)
+
+if 'DYNO' in os.environ:
+    app.wsgi_app = ProxyFix(app.wsgi_app)
+    SSLify(app, age=300, permanent=True)
 
 pf = "coalesce.v1."
 


### PR DESCRIPTION
This seems to be the preferred method for ensuring https and working behind the heroku ssl proxy. And still allows http during local development

http://docs.gunicorn.org/en/stable/settings.html#secure-scheme-headers
https://github.com/kennethreitz/flask-sslify
http://werkzeug.pocoo.org/docs/0.11/contrib/fixers/#werkzeug.contrib.fixers.ProxyFix