### PR TITLE
Bug 1274310 - Use TC coalescer for Linux64 PGO builds. r=dividehex

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -8,14 +8,12 @@ class Config(object):
 
 
 class Production(Config):
-    # TODO: Set actual threshold settings for production keys
     THRESHOLDS = {
         'builds.opt_linux64_pgo': {
             'size': 5,
             'age': 900
         }
     }
-    pass
 
 
 class Development(Config):

--- a/config/config.py
+++ b/config/config.py
@@ -9,6 +9,12 @@ class Config(object):
 
 class Production(Config):
     # TODO: Set actual threshold settings for production keys
+    THRESHOLDS = {
+        'builds.opt_linux64_pgo': {
+            'size': 5,
+            'age': 900
+        }
+    }
     pass
 
 


### PR DESCRIPTION
I may be wrong about the numbers but we can always tweak them if needed. 
I assumed every 5 pending jobs with the eldest more than 30 minutes to be coalesced.